### PR TITLE
new command: revoke PATH_TO_CERT

### DIFF
--- a/lib/letsencrypt/cli/acme_wrapper.rb
+++ b/lib/letsencrypt/cli/acme_wrapper.rb
@@ -105,6 +105,17 @@ class AcmeWrapper
     end
   end
 
+  def revoke_certificate(path)
+    unless File.exists?(path)
+      log "Certificate #{path} does not exists", :warn
+      return false
+    end
+    cert = OpenSSL::X509::Certificate.new(File.read(path))
+    if client.revoke_certificate(cert)
+      log "Certificate '#{path}' was revoked", :info
+    end
+  end
+
   private
 
   def certificate_exists_and_valid?

--- a/lib/letsencrypt/cli/app.rb
+++ b/lib/letsencrypt/cli/app.rb
@@ -71,6 +71,11 @@ module Letsencrypt
         end
       end
 
+      desc "revoke PATH_TO_CERTIFICATE", "revokes a given certificate"
+      def revoke(path)
+        wrapper.revoke_certificate(path)
+      end
+
       desc "manage DOMAINS", "meta command that will: check if cert already exists / still valid (exits zero if nothing todo, exits 2 if certificate is still valid) + authorize given domains + issue certificate for given domains"
       method_option :key_length, desc: "Length of private key", default: 2048, type: :numeric
       method_option :days_valid, desc: "If the --certificate-path already exists, only create new stuff, if that certificate isn't valid for less than the given number of days", default: 30, type: :numeric


### PR DESCRIPTION
Sometimes it is useful to revoke a certificate.

Sorry, no tests since I'm lazy to fiddle with VCR.

One can also try to catch Certificate already revoked (Acme::Client::Error::Malformed) exception.
