### PR TITLE
Rekey on renew

### DIFF
--- a/lib/letsencrypt/cli/app.rb
+++ b/lib/letsencrypt/cli/app.rb
@@ -89,6 +89,7 @@ module Letsencrypt
           exit 2
         end
         authorize(*domains)
+        FileUtils.rm(@options[:private_key_path])
         cert(*domains)
       end
 


### PR DESCRIPTION
Regenerating key when renewing certificate should be mandatory.

There are good reasons to change encryption keys regularly. It protects against long-term key leaks and it hardens decrypting captured traffic in the future.

The fastest way was to delete the key in the renewal process, but i admit it is not very polite to delete the old key before having new certificate issued.
