### PR TITLE
fix renewing via manage command when certificate is not expired

### DIFF
--- a/lib/letsencrypt/cli/acme_wrapper.rb
+++ b/lib/letsencrypt/cli/acme_wrapper.rb
@@ -144,7 +144,7 @@ class AcmeWrapper
       exit 2
     end
 
-    true
+    false 
   end
 
   def endpoint


### PR DESCRIPTION
Renew doesn't work when no domain missing and crt isn't realy expired.

I'm not not sure about "exit 2" i think true will be better there.
