### PR TITLE
fix CSR version

### DIFF
--- a/lib/letsencrypt/cli/acme_wrapper.rb
+++ b/lib/letsencrypt/cli/acme_wrapper.rb
@@ -80,6 +80,7 @@ class AcmeWrapper
         csr.add_attribute(attr)
       end
     end
+    csr.version = 2
     csr.public_key = certificate_private_key.public_key
     csr.sign(certificate_private_key, OpenSSL::Digest::SHA256.new)
     certificate = client.new_certificate(csr)


### PR DESCRIPTION
fix for CSR generated using a pre-1.0.2 OpenSSL with a client that doesn't properly specify the CSR version. See https://community.letsencrypt.org/t/openssl-bug-information/19591 (Acme::Client::Error::Malformed)

fix taken from https://github.com/certbot/certbot/pull/2529/files

https://community.letsencrypt.org/t/openssl-bug-information/19591